### PR TITLE
LDAP Connection method update

### DIFF
--- a/rbcd.py
+++ b/rbcd.py
@@ -43,7 +43,7 @@ logging.info('Initializing LDAP connection to {}'.format(options.dc_ip))
 #tls = ldap3.Tls(validate=ssl.CERT_NONE, version=ssl.PROTOCOL_TLSv1_2)
 serv = ldap3.Server(options.dc_ip, tls=False, get_info=ldap3.ALL)
 logging.info('Using {} account with password ***'.format(attackeraccount[0]))
-conn = ldap3.Connection(serv, user=attackeraccount[0], password=attackeraccount[1], authentication=ldap3.SIMPLE)
+conn = ldap3.Connection(serv, user=attackeraccount[0], password=attackeraccount[1], authentication=ldap3.NTLM)
 conn.bind()
 logging.info('LDAP bind OK')
 


### PR DESCRIPTION
Modified line 46 to change the LDAP connection method from SIMPLE to NTLM. Was on an engagement, SIMPLE wouldn't let me connect to LDAP, but changing it to NTLM did. I assumed this might have been a one-off case, but I looked through the impacket tools, as well as ACLPwn by Fox-IT and they all use the `ldap3.NTLM` connection method. 

End of day, changed for consistency between tools. If it's good enough for Dirkjan, its good enough for me. Great tool!